### PR TITLE
The pictures of most Ajahns on the talks page are clipped #48

### DIFF
--- a/new/components/shared/card/card.css
+++ b/new/components/shared/card/card.css
@@ -14,7 +14,11 @@ CARD
   & .card-img-top {
     width: 100%;
     object-fit: cover;
-    height: 150px;
+    height: 180px;
+  }
+
+  & .card-img-top-fluid {
+    width: 100%;
   }
 
   & .card-title {

--- a/new/components/shared/card/card.js
+++ b/new/components/shared/card/card.js
@@ -22,13 +22,13 @@ class Card extends Component {
             <div>
                 {!this.props.landscape && <div className={"card hidden-sm-down " + (this.props.listItem && "card-list-item")}>
                     <Link to={this.props.href}>
-                        <img className="card-img-top" src={this.props.thumbnail} />
+                        <img className={this.props.fluid ? "card-img-top-fluid" : "card-img-top"} src={this.props.thumbnail} />
+
                         <div className="card-block card-title">
-
                             <span >{this.props.title}</span>
-
                         </div>
                     </Link>
+
                     {this.props.links && <ul className="list-group list-group-flush">
                         {this.props.links.map((link, index) => {
                             return (

--- a/new/components/shared/categories/category-card/category-card.js
+++ b/new/components/shared/categories/category-card/category-card.js
@@ -19,6 +19,7 @@ class CategoryItem extends Component {
                 <Card
                     className=""
                     thumbnail={category.imageUrl}
+                    fluid={true}
                     title={category.title}
                     subtitle={subcategory && subcategory.title}
                     links={category.links}>


### PR DESCRIPTION
PR with the fixes for the issue #48.

Basically, two things changed:

1. The category card now has an image that is 100% width but without a defined height.

![screen shot 2018-01-05 at 18 02 46](https://user-images.githubusercontent.com/403446/34626177-d743ad28-f242-11e7-8c5d-63b1b1254153.png)


2. The default card image now has a height of 180px, which will not crop anything with the 250x250 images. This fixes the height of the teachers and the Subjects pages.

![screen shot 2018-01-05 at 18 02 59](https://user-images.githubusercontent.com/403446/34626182-dbde7700-f242-11e7-87e1-825eba2200d6.png)