### PR TITLE
[Issue 77] Individual Page for each Talk

### DIFF
--- a/new/components/content/talks/talk/talk.js
+++ b/new/components/content/talks/talk/talk.js
@@ -132,12 +132,7 @@ class Talk extends Component {
 
     renderTitle() {
         const { talk } = this.props;
-        if (this.state.full) {
-            return <span>{tp(talk, 'title')}</span>;
-        } else {
-            return <Link to={talk.path} onClick={this.showFull}>
-                        {tp(talk, 'title')}</Link>;
-        }
+        return <Link to={talk.path}>{tp(talk, 'title')}</Link>;
     }
 
     renderPlaylists() {


### PR DESCRIPTION
Issue #77 

Change `Talk` title render function to always link to separate Talk "page", talk can still be expanded on list page by clicking the down chevron below the talk text.