### PR TITLE
Fixes posted at dates

### DIFF
--- a/app/Feed.php
+++ b/app/Feed.php
@@ -87,7 +87,7 @@ class Feed extends FeedWriterFeed
         $item = $this->createNewItem();
         $item->setId($model->getUrl($this->lng, false), true);
         $item->setLink($model->getUrl($this->lng, true));
-        $item->setDate($this->normalizeDate($model->posted_at ?? $model->created_at));
+        $item->setDate($this->normalizeDate($model->getOriginal('posted_at') ?? $model->created_at));
         $item->setTitle($model->title ?? tp($model, 'title', $this->lng));
         $imageUrl = $model->getImagePresetUrl('rss');
         $body = '<p style="text-align: center;">' .

--- a/app/Http/Controllers/Admin/AdminCrudController.php
+++ b/app/Http/Controllers/Admin/AdminCrudController.php
@@ -484,7 +484,7 @@ abstract class AdminCrudController extends CrudController
         ]);
     }
 
-    public function addLocalPostedAtCrudField()
+    public function addPostedAtCrudField()
     {
         $timezone = 'America/Los_Angeles';
         $this->addDateTimeCrudField(

--- a/app/Http/Controllers/Admin/AdminCrudController.php
+++ b/app/Http/Controllers/Admin/AdminCrudController.php
@@ -466,7 +466,7 @@ abstract class AdminCrudController extends CrudController
         ]);
     }
 
-    public function addLocalPostedAtCrudColumn()
+    public function addPostedAtCrudColumn()
     {
         $this->crud->addColumn([
             'name' => 'posted_at',
@@ -491,7 +491,7 @@ abstract class AdminCrudController extends CrudController
             'posted_at',
             'Posted',
             Carbon::now($timezone)->format('d.m.Y'),
-            '(UTC) The original, first posting date. Use rank to control the ordering.'
+            'The original, first posting date. Use rank to control the ordering.'
         );
     }
 

--- a/app/Http/Controllers/Admin/AdminCrudController.php
+++ b/app/Http/Controllers/Admin/AdminCrudController.php
@@ -491,7 +491,7 @@ abstract class AdminCrudController extends CrudController
             'posted_at',
             'Posted',
             Carbon::now($timezone)->format('d.m.Y'),
-            'The original, first posting date. Use rank to control the ordering.'
+            '(UTC) The original, first posting date. Use rank to control the ordering.'
         );
     }
 

--- a/app/Http/Controllers/Admin/AdminCrudController.php
+++ b/app/Http/Controllers/Admin/AdminCrudController.php
@@ -469,7 +469,7 @@ abstract class AdminCrudController extends CrudController
     public function addLocalPostedAtCrudColumn()
     {
         $this->crud->addColumn([
-            'name' => 'local_posted_at',
+            'name' => 'posted_at',
             'label' => 'Posted',
             'type' => 'datetime',
             'attributes' => [
@@ -486,10 +486,9 @@ abstract class AdminCrudController extends CrudController
 
     public function addLocalPostedAtCrudField()
     {
-        // TODO should be local to user
         $timezone = 'America/Los_Angeles';
         $this->addDateTimeCrudField(
-            'local_posted_at',
+            'posted_at',
             'Posted',
             Carbon::now($timezone)->format('d.m.Y'),
             'The original, first posting date. Use rank to control the ordering.'

--- a/app/Http/Controllers/Admin/BookCrudController.php
+++ b/app/Http/Controllers/Admin/BookCrudController.php
@@ -37,7 +37,7 @@ class BookCrudController extends AdminCrudController
             'function_name' => 'getAvailabilityCrudColumnHtml',
         ]);
         $this->addCheckTranslationCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()
@@ -69,7 +69,7 @@ class BookCrudController extends AdminCrudController
             'type' => 'checkbox',
         ]);
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/NewsCrudController.php
+++ b/app/Http/Controllers/Admin/NewsCrudController.php
@@ -34,7 +34,7 @@ class NewsCrudController extends AdminCrudController
         $this->addTitleEnCrudColumn();
         $this->addRankCrudColumn();
         $this->addDraftCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()
@@ -49,7 +49,7 @@ class NewsCrudController extends AdminCrudController
         $this->addImageCrudField();
         $this->addDraftCrudField();
         $this->addNullableRankCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/PlaylistCrudController.php
+++ b/app/Http/Controllers/Admin/PlaylistCrudController.php
@@ -40,7 +40,7 @@ class PlaylistCrudController extends AdminCrudController
         $this->addTitleEnCrudColumn();
         $this->addTitleThCrudColumn();
         $this->addCheckTranslationCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()
@@ -68,7 +68,7 @@ class PlaylistCrudController extends AdminCrudController
         $this->addImageCrudField();
         $this->addRankCrudField();
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/ReflectionCrudController.php
+++ b/app/Http/Controllers/Admin/ReflectionCrudController.php
@@ -31,7 +31,7 @@ class ReflectionCrudController extends AdminCrudController
 
         $this->addAuthorCrudColumn();
         $this->addTitleCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()
@@ -47,7 +47,7 @@ class ReflectionCrudController extends AdminCrudController
         $this->addBodyCrudField();
         $this->addImageCrudField();
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/SubpageCrudController.php
+++ b/app/Http/Controllers/Admin/SubpageCrudController.php
@@ -57,7 +57,7 @@ class SubpageCrudController extends AdminCrudController
         $this->addCheckTranslationCrudField();
         $this->addRankCrudField();
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/TaleCrudController.php
+++ b/app/Http/Controllers/Admin/TaleCrudController.php
@@ -31,7 +31,7 @@ class TaleCrudController extends AdminCrudController
 
         $this->addAuthorCrudColumn();
         $this->addTitleEnCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()
@@ -45,7 +45,7 @@ class TaleCrudController extends AdminCrudController
         $this->addBodyThCrudField();
         $this->addImageCrudField();
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/TalkCrudController.php
+++ b/app/Http/Controllers/Admin/TalkCrudController.php
@@ -79,7 +79,7 @@ class TalkCrudController extends AdminCrudController
             'hint' => "Check this box if this talk shouldn't show up on the latest talks page (e.g. retreat talks).",
         ]);
         $this->addDraftCrudField();
-        $this->addLocalPostedAtCrudField();
+        $this->addPostedAtCrudField();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/TalkCrudController.php
+++ b/app/Http/Controllers/Admin/TalkCrudController.php
@@ -31,7 +31,7 @@ class TalkCrudController extends AdminCrudController
 
         $this->addTitleEnCrudColumn();
         $this->addAuthorCrudColumn();
-        $this->addLocalPostedAtCrudColumn();
+        $this->addPostedAtCrudColumn();
     }
 
     protected function setupCreateOperation()

--- a/app/Http/Requests/BookRequest.php
+++ b/app/Http/Requests/BookRequest.php
@@ -32,7 +32,7 @@ class BookRequest extends FormRequest
             'alt_title_en' => 'nullable|max:255',
             'alt_title_th' => 'nullable|max:255',
             'published_on' => 'required|date',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
         ];
     }
 }

--- a/app/Http/Requests/NewsRequest.php
+++ b/app/Http/Requests/NewsRequest.php
@@ -27,7 +27,7 @@ class NewsRequest extends FormRequest
         return [
             'title_en' => 'required|max:255',
             'title_th' => 'nullable|max:255',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
             'rank' => 'nullable|numeric|min:1',
         ];
     }

--- a/app/Http/Requests/ReflectionRequest.php
+++ b/app/Http/Requests/ReflectionRequest.php
@@ -28,7 +28,7 @@ class ReflectionRequest extends FormRequest
             'title' => 'required|max:255',
             'alt_title_en' => 'nullable|max:255',
             'alt_title_th' => 'nullable|max:255',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
         ];
     }
 }

--- a/app/Http/Requests/SubpageRequest.php
+++ b/app/Http/Requests/SubpageRequest.php
@@ -29,7 +29,7 @@ class SubpageRequest extends FormRequest
             'subpath' => 'required|max:255',
             'title_en' => 'required|max:255',
             'title_th' => 'nullable|max:255',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
         ];
     }
 }

--- a/app/Http/Requests/TaleRequest.php
+++ b/app/Http/Requests/TaleRequest.php
@@ -26,7 +26,7 @@ class TaleRequest extends FormRequest
     {
         return [
             'title_en' => 'required|max:255',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
         ];
     }
 }

--- a/app/Http/Requests/TalkRequest.php
+++ b/app/Http/Requests/TalkRequest.php
@@ -53,7 +53,7 @@ class TalkRequest extends FormRequest
             'playlists' => 'required',
             'youtube_video_id' => 'nullable|max:255|unique:talks,youtube_video_id,' . $this->input('id'),
             'recorded_on' => 'required|date',
-            'local_posted_at' => 'required|date',
+            'posted_at' => 'required|date',
         ];
     }
 }

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -58,8 +58,7 @@ class Book extends Model
      * @var array
      */
     protected $appends = ['description_html_en', 'description_html_th',
-        'image_url', 'pdf_url', 'epub_url', 'mobi_url',
-        'local_posted_at', 'url_title'];
+        'image_url', 'pdf_url', 'epub_url', 'mobi_url', 'url_title'];
 
     /**
      * The attributes that should not be revisioned.

--- a/app/Models/Traits/LocalDateTimeTrait.php
+++ b/app/Models/Traits/LocalDateTimeTrait.php
@@ -6,17 +6,6 @@ use Carbon\Carbon;
 
 trait LocalDateTimeTrait
 {
-    protected function getLocalDateTimeFrom($name)
-    {
-        $value = $this->getAttribute($name);
-        if ($value) {
-            $date = (new Carbon($value))->tz($this->getLocalTimeZone());
-            return $date->toDateTimeString();
-        } else {
-            return null;
-        }
-    }
-
     protected function setLocalDateTimeTo($name, $value)
     {
         if ($value) {

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -45,6 +45,10 @@ trait PostedAtTrait
      */
     public function getPostedAtAttribute($postedAt): ?Carbon
     {
+        if ($postedAt === null) {
+            return null;
+        }
+
         return Carbon::parse($postedAt, 'UTC')->setTimezone('America/Los_Angeles');
     }
 

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -56,9 +56,9 @@ trait PostedAtTrait
      */
     public function isPublic(): bool
     {
-        $postedAt = Carbon::parse($this->getOriginal('posted_at'), 'UTC');
+        $postedAt = Carbon::parse($this->getOriginal('posted_at'));
 
-        return !$this->draft && $this->posted_at && ($this->posted_at < now());
+        return !$this->draft && $postedAt && $postedAt->lt(now());
     }
 
     /**
@@ -83,16 +83,21 @@ trait PostedAtTrait
      */
     public function wasUpdatedAfterPosting(?Carbon $minDate = null): bool
     {
-        if ($this->updated_at && $this->posted_at &&
-            ($this->posted_at->diffInDays($this->updated_at) > 2)) {
+        $postedAt = $this->getOriginal('posted_at');
+
+        if ($postedAt !== null) {
+            $postedAt = Carbon::parse($postedAt);
+        }
+
+        if ($this->updated_at && $postedAt && $postedAt->diffInDays($this->updated_at) > 2) {
             // TODO this is a hardcoded date due to an import that occured on
             // this date.
             if (!$minDate) {
                 $minDate = Carbon::parse('2 months ago');
             }
-            return $this->posted_at->greaterThan($minDate);
-        } else {
-            return false;
+            return $postedAt->greaterThan($minDate);
         }
+
+        return false;
     }
 }

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -68,7 +68,7 @@ trait PostedAtTrait
      */
     public function setPostedAtAttribute($value): void
     {
-        $this->attributes['posted_at'] = Carbon::parse($value)->toDateTimeString();
+        $this->setLocalDateTimeTo('posted_at', $value);
     }
 
     /**

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -64,11 +64,11 @@ trait PostedAtTrait
      *
      * @param  Carbon|string  $value
      *
-     * @return string
+     * @return void
      */
-    public function setLocalPostedAtAttribute($value): ?string
+    public function setPostedAtAttribute($value): void
     {
-        return $this->setLocalDateTimeTo('posted_at', $value);
+        $this->attributes['posted_at'] = Carbon::parse($value)->toDateTimeString();
     }
 
     /**

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -60,7 +60,11 @@ trait PostedAtTrait
      */
     public function isPublic(): bool
     {
-        $postedAt = Carbon::parse($this->getOriginal('posted_at'));
+        $postedAt = $this->getOriginal('posted_at');
+
+        if ($postedAt !== null) {
+            $postedAt = Carbon::parse($postedAt);
+        }
 
         return !$this->draft && $postedAt && $postedAt->lt(now());
     }

--- a/app/Models/Traits/PostedAtTrait.php
+++ b/app/Models/Traits/PostedAtTrait.php
@@ -41,11 +41,11 @@ trait PostedAtTrait
     /**
      * Returns the local time from posted_at.
      *
-     * @return string|null
+     * @return Carbon|null
      */
-    public function getLocalPostedAtAttribute(): ?string
+    public function getPostedAtAttribute($postedAt): ?Carbon
     {
-        return $this->getLocalDateTimeFrom('posted_at');
+        return Carbon::parse($postedAt, 'UTC')->setTimezone('America/Los_Angeles');
     }
 
     /**
@@ -56,6 +56,8 @@ trait PostedAtTrait
      */
     public function isPublic(): bool
     {
+        $postedAt = Carbon::parse($this->getOriginal('posted_at'), 'UTC');
+
         return !$this->draft && $this->posted_at && ($this->posted_at < now());
     }
 

--- a/tests/Unit/Models/Traits/PostedAtTraitTest.php
+++ b/tests/Unit/Models/Traits/PostedAtTraitTest.php
@@ -2,14 +2,18 @@
 
 namespace Tests\Unit\Models\Traits;
 
+use App\Models\Talk;
 use App\Models\Traits\LocalDateTimeTrait;
 use App\Models\Traits\PostedAtTrait;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class PostedAtTraitTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function testAccessors()
     {
         $m = new class() extends Model {
@@ -41,5 +45,26 @@ class PostedAtTraitTest extends TestCase
         $this->assertTrue($m->wasUpdatedAfterPosting($minDate));
         $m->posted_at = new Carbon('2017-03-01T12:00:00Z');
         $this->assertFalse($m->wasUpdatedAfterPosting($minDate));
+    }
+
+
+    /** @test */
+    public function stores_posted_at_on_utc()
+    {
+        $talk = factory(Talk::class)->create([
+            'posted_at' => '2020-01-01 12:00:00', // PST
+        ]);
+
+        $this->assertEquals('2020-01-01 20:00:00', $talk->getOriginal('posted_at'));
+    }
+
+    /** @test */
+    public function shows_posted_at_on_pst()
+    {
+        $talk = factory(Talk::class)->create([
+              'posted_at' => '2020-01-01 12:00:00', // PST
+          ]);
+
+        $this->assertEquals('2020-01-01 12:00:00', $talk->posted_at);
     }
 }


### PR DESCRIPTION
The `setLocalPostedAtAttribute` is never called since the Model doesn't have that property. 

Backpack will update the model using this statement and won't trigger the `setLocalPostedAttribute`:

```php
$model->update([
  ...,
  'local_posted_at' => '2020-01-01 00:00'
])
```

This doesn't trigger a SQL exception (posted_at is not nullable). For some reason, the `posted_at` column is set as `0000-00-00 00:00`.

This PR adds an accessor and mutator for the `posted_at` column to fix this issue. The mutator will convert all dates from PST to UTC and the accessor will convert UTC to PST.