### PR TITLE
Use pingback on kernel command to confirm uptime

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -38,7 +38,11 @@ class Kernel extends ConsoleKernel
         //    ->dailyAt('13:52');
 
         $common($schedule->command('app:sync-gallery'))
-            ->everyFifteenMinutes();
+            ->everyFifteenMinutes()
+            ->thenPingIf(
+                config('services.ohdear.scheduled_tasks_ping_url'),
+                config('services.ohdear.scheduled_tasks_ping_url')
+            );
 
         $schedule->call([Calendar::class, 'preCacheEvents'])
             ->everyFiveMinutes();

--- a/config/services.php
+++ b/config/services.php
@@ -26,6 +26,10 @@ return [
         'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
     ],
 
+    'ohdear' => [
+        'scheduled_tasks_ping_url' => env('SERVICES_OHDEAR_SCHEDULED_TASKS_PING_URL', false),
+    ],
+
     'postmark' => [
         'token' => env('POSTMARK_TOKEN'),
     ],


### PR DESCRIPTION
We'll need to update the ENV on production to include the ohdear! pingback URL after this is deployed.