### PR TITLE
Remove usage of custom DO driver

### DIFF
--- a/app/Utilities/ImageCacheServer.php
+++ b/app/Utilities/ImageCacheServer.php
@@ -6,7 +6,6 @@ use Aws\S3\S3Client;
 use League\Glide\Server;
 use League\Glide\ServerFactory;
 use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Local;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 

--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -34,12 +34,6 @@ return [
             // only way it seems to get thumbnails generating properly
             'tmbPath' => public_path('img/elfinder-tmb'),
             'tmbURL' => env('APP_URL') . '/img/elfinder-tmb',
-            // This is workaround to avoid n+1 queries to Digital Ocean Spaces
-            // during directory listings. This tells elFinder to use the
-            // App\Utilities\elFinderDigitalOceanSpacesDriver class (a.k.a.
-            // elFinderVolumeDigitalOceanSpaces) instead of
-            // Barryvdh\elFinderFlysystemDriver\Driver.
-            'driver' => 'DigitalOceanSpaces',
         ],
     ] : null,
 


### PR DESCRIPTION
Fixes list of files not working due to using this custom driver.
 
We upgraded the Elfinder version, so I think the need for the workaround might be fixed. I tested this locally with the DO spaces bucket and can't see any N+1 issue. 

I'd like to push to prod for now to fix the production error and see how it behaves.