### PR TITLE
Add spaces-media driver with public visibility

### DIFF
--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -26,9 +26,9 @@ return [
     |    ]
     */
     'disks' => env('DO_SPACES_URL') ? [
-        'spaces' => [
-            'alias' => 'media',
+        'spaces-media' => [
             'URL' => env('DO_SPACES_URL') . '/media',
+            'alias' => 'media',
             'path' => 'media',
             // HACK: this won't work if we go beyond 1 server, but it's the
             // only way it seems to get thumbnails generating properly

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -74,6 +74,15 @@ return [
             'url' => env('DO_SPACES_URL'),
         ],
 
+        'spaces-media'  => [
+            'driver' => 's3',
+            'key' => env('DO_SPACES_KEY'),
+            'secret' => env('DO_SPACES_SECRET'),
+            'endpoint' => env('DO_SPACES_ENDPOINT'),
+            'region' => env('DO_SPACES_REGION'),
+            'bucket' => env('DO_SPACES_BUCKET'),
+            'visibility' => 'public',
+        ],
     ],
 
     'uploads' => [


### PR DESCRIPTION
The custom elfinder  driver was setting the public visibility when uploading files: https://github.com/abhayagiri/abhayagiri-website/blob/dev/app/Utilities/elFinderDigitalOceanSpacesDriver.php#L26

The usage of that class was deleted on a previous PR. This PR adds a spaces-media driver with public visibility for all /media files.