### PR TITLE
Clean up the old deployment folder

### DIFF
--- a/scripts/forge/deploy.sh
+++ b/scripts/forge/deploy.sh
@@ -91,3 +91,8 @@ if [ "$SENTRY_AUTH_TOKEN" != "" ]; then
 else
     echo "SENTRY_AUTH_TOKEN not found in .env"
 fi
+
+# Clean up old deployment folder
+if [ -d "$HOME/$DEPLOY_PROJECT.old" ]; then
+    rm -rf "$HOME/$DEPLOY_PROJECT.old"
+fi


### PR DESCRIPTION
The deployment scripts follows a zero-downtime pattern by creating a .old directory. However after the deployment succeeds the folder isn't cleaned-up taking up disk space.